### PR TITLE
Add optional dependencies for `validation`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
 "Homepage" = "https://codebase.helmholtz.cloud/metamosim/metadata_archivist.git"
 
 [project.optional-dependencies]
+validation = [
+  "jsonschema",
+]
 examples = [
   "pyyaml",
   "jsonschema",


### PR DESCRIPTION
The readme describes an optional dependency towards `jsonschema`. This change reflects this in `pyproject.toml` by declaring `validation` dependencies.